### PR TITLE
Fix deprecated MQTT publish options

### DIFF
--- a/yaml/script/valetudo-send-vacuum-command.yaml
+++ b/yaml/script/valetudo-send-vacuum-command.yaml
@@ -26,8 +26,8 @@ sequence:
   - alias: Publish MQTT topic
     service: mqtt.publish
     data:
-      topic_template: '{{valetudo_prefix|trim}}/{{robot_prefix|trim}}/{{mqtt_topic|trim}}'
-      payload_template: '{{mqtt_payload|trim}}'
+      topic: '{{valetudo_prefix|trim}}/{{robot_prefix|trim}}/{{mqtt_topic|trim}}'
+      payload: '{{mqtt_payload|trim}}'
 fields:
   mqtt_topic:
     name: Topic


### PR DESCRIPTION
Home Assistant notified me with some repair notices that the '*_template' options should
have that suffix removed.