### PR TITLE
Make camera selector compatible with MQTT Vacuum Camera integration.

### DIFF
--- a/yaml/automation/valetudo-notifications.yaml
+++ b/yaml/automation/valetudo-notifications.yaml
@@ -19,8 +19,11 @@ blueprint:
         description: The vacuum map rendered as a PNG image.
         selector:
             entity:
-                domain: camera
-                integration: mqtt
+                filter:
+                    - domain: camera
+                      integration: mqtt
+                    - domain: camera
+                      integration: mqtt_vacuum_camera
                 multiple: false
     error_message:
         name: Error Message


### PR DESCRIPTION
I'm using https://github.com/sca075/mqtt_vacuum_camera/ to generate my map images. Because this is a custom integration I can't select its camera entity when there is a filter for "integration: mqtt". 